### PR TITLE
fix: handle custom meta headers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         "ext-iconv": "*",
         "symfony/console": "6.0.*",
         "symfony/dotenv": "6.0.*",
+        "symfony/expression-language": "6.0.*",
         "symfony/flex": "^2",
         "symfony/framework-bundle": "6.0.*",
         "symfony/runtime": "6.0.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e89455bcd949962d4c5fe5f334d7f4c8",
+    "content-hash": "eee0a32321e770792c61e01279655dca",
     "packages": [
         {
             "name": "psr/cache",
@@ -1010,6 +1010,69 @@
                 }
             ],
             "time": "2021-07-15T12:33:35+00:00"
+        },
+        {
+            "name": "symfony/expression-language",
+            "version": "v6.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/expression-language.git",
+                "reference": "7affe5d5e579cd89c664b364f74ce2d01d57cf29"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/expression-language/zipball/7affe5d5e579cd89c664b364f74ce2d01d57cf29",
+                "reference": "7affe5d5e579cd89c664b364f74ce2d01d57cf29",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.2",
+                "symfony/cache": "^5.4|^6.0",
+                "symfony/service-contracts": "^1.1|^2|^3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\ExpressionLanguage\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an engine that can compile and evaluate expressions",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/expression-language/tree/v6.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-04-12T16:11:42+00:00"
         },
         {
             "name": "symfony/filesystem",

--- a/src/Controller/ExampleController.php
+++ b/src/Controller/ExampleController.php
@@ -29,7 +29,7 @@ class ExampleController
         ]);
     }
 
-    #[Route('/api/examples', methods: ['POST'], name: 'api_example_post')]
+    #[Route('/api/examples', name: 'api_example_post', methods: ['POST'], condition: "request.headers.get('Content-Type') matches '/application\\\\/json/i'")]
     public function postAction(Request $request): Response
     {
         $id = mt_rand(2, 100);

--- a/symfony.lock
+++ b/symfony.lock
@@ -181,6 +181,9 @@
     "symfony/event-dispatcher-contracts": {
         "version": "v3.0.0"
     },
+    "symfony/expression-language": {
+        "version": "v6.0.8"
+    },
     "symfony/filesystem": {
         "version": "v6.0.3"
     },

--- a/tests/Functional/AbstractApiTest.php
+++ b/tests/Functional/AbstractApiTest.php
@@ -41,7 +41,12 @@ abstract class AbstractApiTest extends WebTestCase
         /** @var array<string, string> $server */
         $server = [];
         foreach ($headers as $key => $value) {
-            $server['HTTP_' . strtoupper(str_replace('-', '_', $key))] = $value;
+            // custom header https://symfony.com/doc/current/testing.html#sending-custom-headers
+            if(str_starts_with($key, 'X-')) {
+                $server['HTTP_' . strtoupper(str_replace('-', '_', $key))] = $value;
+            } else {
+                $server[strtoupper(str_replace('-', '_', $key))] =  $value;
+            }
         }
 
         // act

--- a/tests/Functional/Controller/fixtures/example_post.md
+++ b/tests/Functional/Controller/fixtures/example_post.md
@@ -3,6 +3,8 @@
 ```http request
 POST /api/examples
 Accept: application/json
+Content-Type: application/json
+X-Auth-Token: e1f4ec0d-54df-465e-8cf3-78dad2ca8463
 ```
 
 ```json


### PR DESCRIPTION
If server require X-Auth-Token: some-uuid ,
the header should be HTTP_X_AUTH_TOKEN.

If server only accept Content-Type: application/json ,
the header should be CONTENT_TYPE, not HTTP_CONTENT_TYPE.

I figured this out by adding a condition on Content-Type on Route attribute using symfony/expression-language